### PR TITLE
Update README.md with new amplify-app command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cd amplify-datastore
 Add support for datastore, it creates the API for you (there is no need to type `amplify add api` after this)
 
 ```sh
-npx amplify-app
+npx amplify-app --platform javascript --framework react
 ```
 
 ## Add our GraphQL schema 


### PR DESCRIPTION
For javascript and react app to work we need the command line "npx amplify-app --platform javascript --framework react" instead of just "npx amplify-app". The old command gives an error and also treats the repo as an Android repo.